### PR TITLE
Feature: Add custom API Base URL support

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -26,11 +26,11 @@ export class InputModal extends Modal {
     let {  contentEl, containerEl, modalEl } = this;
     contentEl.createEl("h1", { text: "Prompt configuration" });
 
-    new Setting(contentEl)
+new Setting(contentEl)
     .setName("Model")
-    .addDropdown((dropdown) =>
-      dropdown
-	  .addOptions(Object.fromEntries(allAvailableModels().map(k => [k, k])))
+    .addText((text) =>
+      text
+      .setPlaceholder("gpt-4o") // <-- This is optional, but it helps the user
       .setValue(this.configuration.model)
       .onChange(async (value) => {
 		reasoningEffortSetting.setDisabled(!availableReasoningModels().includes(value));

--- a/src/flashcards.ts
+++ b/src/flashcards.ts
@@ -69,6 +69,7 @@ Rules:
 export async function* generateFlashcards(
 	text: string,
 	apiKey: string,
+	baseURL: string,
 	model: string = "gpt-4o",
 	sep: string = "::",
 	flashcardsCount: number = 3,
@@ -81,7 +82,8 @@ export async function* generateFlashcards(
 
 	const openai = new OpenAI({
 		apiKey: apiKey,
-		dangerouslyAllowBrowser: true
+		dangerouslyAllowBrowser: true,
+		baseURL: baseURL || undefined
 	});
 
 	const cleanedText = text.replace(/<!--.*-->[\n]?/g, "");
@@ -103,7 +105,7 @@ the original task): ${additionalInfo}`
 
 	// TODO: use newer client.responses.create endpoint.
 	// TODO: use structured (json) output to enforce flashcards formatting
-	if (chatModels.includes(model) || reasoningModels.includes(model)) {
+	if (baseURL || chatModels.includes(model) || reasoningModels.includes(model)) {
 		response = await openai.chat.completions.create({
 		model: model,
 		...(!isReasoning && { temperature: 0.7 }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { FlashcardsSettings, FlashcardsSettingsTab } from "./settings"
 
 const DEFAULT_SETTINGS: FlashcardsSettings = {
   apiKey: "",
+  baseURL: "",
   model: "gpt-4o",
   inlineSeparator: "::",
   multilineSeparator: "?",
@@ -80,6 +81,7 @@ export default class FlashcardsLLMPlugin extends Plugin {
   }
 
   async onGenerateFlashcards(editor: Editor, view: MarkdownView, configuration: FlashcardsSettings, multiline: boolean = false) {
+    const baseURL = configuration.baseURL;
     const apiKey = configuration.apiKey;
     if (!apiKey) {
       new Notice("API key is not set in plugin settings");
@@ -129,6 +131,7 @@ export default class FlashcardsLLMPlugin extends Plugin {
       const generatedFlashcards = await generateFlashcards(
         currentText,
         apiKey,
+        baseURL,
         model,
         sep,
         flashcardsCount,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import FlashcardsLLMPlugin from "./main"
 
 export interface FlashcardsSettings {
   apiKey: string;
+  baseURL: string;
   model: string;
   inlineSeparator: string;
   multilineSeparator: string;
@@ -49,18 +50,32 @@ export class FlashcardsSettingsTab extends PluginSettingTab {
     );
 
     new Setting(containerEl)
-    .setName("Model")
-    .setDesc("Which language model to use")
-    .addDropdown((dropdown) =>
-      dropdown
-	  .addOptions(Object.fromEntries(allAvailableModels().map(k => [k, k])))
-      .setValue(this.plugin.settings.model)
+    .setName("API Base URL (Optional)")
+    .setDesc("Override the base URL to use proxies or local models (e.g. Ollama, Groq).")
+    .addText((text) =>
+      text
+      .setPlaceholder("https.api.openai.com/v1") // Placeholder
+      .setValue(this.plugin.settings.baseURL)
       .onChange(async (value) => {
-        this.plugin.settings.model = value;
-		reasoningEffortSetting.setDisabled(!availableReasoningModels().includes(value));
+        // Remove trailing slash if the user adds it, for consistency
+        this.plugin.settings.baseURL = value.endsWith("/") ? value.slice(0, -1) : value;
         await this.plugin.saveSettings();
       })
     );
+
+ new Setting(containerEl)
+.setName("Model")
+.setDesc("Which language model to use (e.g. gpt-4o, llama3, etc.)")
+.addText((text) => 
+  text
+  .setPlaceholder("gpt-4o-mini")
+  .setValue(this.plugin.settings.model)
+  .onChange(async (value) => {
+    this.plugin.settings.model = value;
+    reasoningEffortSetting.setDisabled(!availableReasoningModels().includes(value)); 
+    await this.plugin.saveSettings();
+  })
+);
 
     const reasoningEffortSetting = new Setting(containerEl)
     .setName("Reasoning Effort")


### PR DESCRIPTION
Hi @crybot,

Thank you for this great plugin. I've added a feature that allows users to specify a custom API Base URL in the settings.

This change makes the plugin compatible with third-party providers like OpenRouter, Groq, and local models via Ollama (which was my personal use case).

**What I changed:**

* **`settings.ts` / `components.ts`**: Added a new text field for the `baseURL` and changed the "Model" dropdown to a text field to allow custom model names.
* **`main.ts`**: Passed the new `baseURL` from settings to the generation function.
* **`flashcards.ts`**: 
    1.  Passed the `baseURL` to the `OpenAI` constructor.
    2.  Updated the model validation logic to allow custom models if a `baseURL` is present.

The plugin remains fully compatible with the original OpenAI API if the `baseURL` field is left empty.

I hope you find this contribution useful!